### PR TITLE
fix: correct swapped used/hard in quota errors and logr misuse

### DIFF
--- a/api/v1/configmap_webhook.go
+++ b/api/v1/configmap_webhook.go
@@ -104,7 +104,7 @@ func (v *configMapValidator) ValidateCreate(ctx context.Context, cm *corev1.Conf
 	used := prq.Status.Used[corev1.ResourceConfigMaps]
 
 	if hard.Cmp(prq.Status.Used[corev1.ResourceConfigMaps]) != 1 {
-		return nil, fmt.Errorf("over project resource quota. current %s counts %s, hard limit count %s", corev1.ResourceConfigMaps, hard.String(), used.String())
+		return nil, fmt.Errorf("over project resource quota. current %s counts %s, hard limit count %s", corev1.ResourceConfigMaps, used.String(), hard.String())
 	}
 	return nil, nil
 }

--- a/api/v1/persistentvolumeclaim_webhook.go
+++ b/api/v1/persistentvolumeclaim_webhook.go
@@ -104,7 +104,7 @@ func (v *persistentVolumeClaimValidator) ValidateCreate(ctx context.Context, pvc
 	used := prq.Status.Used[corev1.ResourcePersistentVolumeClaims]
 
 	if hard.Cmp(prq.Status.Used[corev1.ResourcePersistentVolumeClaims]) != 1 {
-		return nil, fmt.Errorf("over project resource quota. current %s counts %s, hard limit count %s", corev1.ResourcePersistentVolumeClaims, hard.String(), used.String())
+		return nil, fmt.Errorf("over project resource quota. current %s counts %s, hard limit count %s", corev1.ResourcePersistentVolumeClaims, used.String(), hard.String())
 	}
 	return nil, nil
 }

--- a/api/v1/pod_webhook.go
+++ b/api/v1/pod_webhook.go
@@ -104,7 +104,7 @@ func (v *podValidator) ValidateCreate(ctx context.Context, pod *corev1.Pod) (adm
 	used := prq.Status.Used[corev1.ResourcePods]
 	hard := prq.Spec.Hard[corev1.ResourcePods]
 	if hard.Cmp(used) != 1 {
-		return nil, fmt.Errorf("over project resource quota. current %s counts %v, hard limit count %v", corev1.ResourcePods, hard.String(), used.String())
+		return nil, fmt.Errorf("over project resource quota. current %s counts %v, hard limit count %v", corev1.ResourcePods, used.String(), hard.String())
 	}
 
 	// calculate resource requests and limits
@@ -212,21 +212,21 @@ func (v *podValidator) ValidateCreate(ctx context.Context, pod *corev1.Pod) (adm
 	hard = prq.Spec.Hard[corev1.ResourceLimitsCPU]
 	limitCPU.Add(used)
 	if limitCPU.Cmp(hard) == 1 {
-		return nil, fmt.Errorf("over project resource quota. %s request %v + used %v > hard limit %v", corev1.ResourceLimitsCPU, requestCPU.String(), used.String(), hard.String())
+		return nil, fmt.Errorf("over project resource quota. %s request %v + used %v > hard limit %v", corev1.ResourceLimitsCPU, limitCPU.String(), used.String(), hard.String())
 	}
 
 	used = prq.Status.Used[corev1.ResourceLimitsMemory]
 	hard = prq.Spec.Hard[corev1.ResourceLimitsMemory]
 	limitMemory.Add(used)
 	if limitMemory.Cmp(hard) == 1 {
-		return nil, fmt.Errorf("over project resource quota. %s request %v + used %v > hard limit %v", corev1.ResourceLimitsMemory, requestMemory.String(), used.String(), hard.String())
+		return nil, fmt.Errorf("over project resource quota. %s request %v + used %v > hard limit %v", corev1.ResourceLimitsMemory, limitMemory.String(), used.String(), hard.String())
 	}
 
 	used = prq.Status.Used[corev1.ResourceLimitsEphemeralStorage]
 	hard = prq.Spec.Hard[corev1.ResourceLimitsEphemeralStorage]
 	limitEphemeralStorage.Add(used)
 	if limitEphemeralStorage.Cmp(hard) == 1 {
-		return nil, fmt.Errorf("over project resource quota. %s request %v + used %v > hard limit %v", corev1.ResourceRequestsEphemeralStorage, requestEphemeralStorage.String(), used.String(), hard.String())
+		return nil, fmt.Errorf("over project resource quota. %s request %v + used %v > hard limit %v", corev1.ResourceLimitsEphemeralStorage, limitEphemeralStorage.String(), used.String(), hard.String())
 	}
 	return nil, nil
 }

--- a/api/v1/replicationcontroller_webhook.go
+++ b/api/v1/replicationcontroller_webhook.go
@@ -104,7 +104,7 @@ func (v *replicationControllerValidator) ValidateCreate(ctx context.Context, rc 
 	used := prq.Status.Used[corev1.ResourceReplicationControllers]
 
 	if hard.Cmp(prq.Status.Used[corev1.ResourceReplicationControllers]) != 1 {
-		return nil, fmt.Errorf("over project resource quota. current %s counts %s, hard limit count %s", corev1.ResourceReplicationControllers, hard.String(), used.String())
+		return nil, fmt.Errorf("over project resource quota. current %s counts %s, hard limit count %s", corev1.ResourceReplicationControllers, used.String(), hard.String())
 	}
 	return nil, nil
 }

--- a/api/v1/resourcequota_webhook.go
+++ b/api/v1/resourcequota_webhook.go
@@ -104,7 +104,7 @@ func (v *resourceQuotaValidator) ValidateCreate(ctx context.Context, resourceQuo
 	used := prq.Status.Used[corev1.ResourceQuotas]
 
 	if hard.Cmp(prq.Status.Used[corev1.ResourceQuotas]) != 1 {
-		return nil, fmt.Errorf("over project resource quota. current %s counts %s, hard limit count %s", corev1.ResourceQuotas, hard.String(), used.String())
+		return nil, fmt.Errorf("over project resource quota. current %s counts %s, hard limit count %s", corev1.ResourceQuotas, used.String(), hard.String())
 	}
 	return nil, nil
 }

--- a/api/v1/secret_webhook.go
+++ b/api/v1/secret_webhook.go
@@ -104,7 +104,7 @@ func (v *secretValidator) ValidateCreate(ctx context.Context, secret *corev1.Sec
 	used := prq.Status.Used[corev1.ResourceSecrets]
 
 	if hard.Cmp(prq.Status.Used[corev1.ResourceSecrets]) != 1 {
-		return nil, fmt.Errorf("over project resource quota. current %s counts %s, hard limit count %s", corev1.ResourceSecrets, hard.String(), used.String())
+		return nil, fmt.Errorf("over project resource quota. current %s counts %s, hard limit count %s", corev1.ResourceSecrets, used.String(), hard.String())
 	}
 	return nil, nil
 }

--- a/api/v1/service_webhook.go
+++ b/api/v1/service_webhook.go
@@ -86,10 +86,10 @@ type serviceValidator struct {
 
 func (v *serviceValidator) validateService(ctx context.Context, svc *corev1.Service, prq *ProjectResourceQuota) error {
 	// check the status.used.services is less than spec.hard.services
-	hard := prq.Spec.Hard[corev1.ResourceServices]
 	used := prq.Status.Used[corev1.ResourceServices]
+	hard := prq.Spec.Hard[corev1.ResourceServices]
 
-	if hard.Cmp(prq.Status.Used[corev1.ResourceServices]) != 1 {
+	if hard.Cmp(used) != 1 {
 		return fmt.Errorf("over project resource quota. current %s counts %s, hard limit count %s", corev1.ResourceServices, used.String(), hard.String())
 	}
 	return nil
@@ -97,10 +97,10 @@ func (v *serviceValidator) validateService(ctx context.Context, svc *corev1.Serv
 
 func (v *serviceValidator) validateServiceNodePort(ctx context.Context, svc *corev1.Service, prq *ProjectResourceQuota) error {
 	// check the status.used.services.nodeports is less than spec.hard.services.nodeports
-	hard := prq.Spec.Hard[corev1.ResourceServicesNodePorts]
 	used := prq.Status.Used[corev1.ResourceServicesNodePorts]
+	hard := prq.Spec.Hard[corev1.ResourceServicesNodePorts]
 
-	if hard.Cmp(prq.Status.Used[corev1.ResourceServicesNodePorts]) != 1 {
+	if hard.Cmp(used) != 1 {
 		return fmt.Errorf("over project resource quota. current %s counts %s, hard limit count %s", corev1.ResourceServicesNodePorts, used.String(), hard.String())
 	}
 	return nil
@@ -108,10 +108,10 @@ func (v *serviceValidator) validateServiceNodePort(ctx context.Context, svc *cor
 
 func (v *serviceValidator) validateServiceLoadBalancer(ctx context.Context, svc *corev1.Service, prq *ProjectResourceQuota) error {
 	// check the status.used.services.loadbalancers is less than spec.hard.services.loadbalancers
-	hard := prq.Spec.Hard[corev1.ResourceServicesLoadBalancers]
 	used := prq.Status.Used[corev1.ResourceServicesLoadBalancers]
+	hard := prq.Spec.Hard[corev1.ResourceServicesLoadBalancers]
 
-	if hard.Cmp(prq.Status.Used[corev1.ResourceServicesLoadBalancers]) != 1 {
+	if hard.Cmp(used) != 1 {
 		return fmt.Errorf("over project resource quota. current %s counts %s, hard limit count %s", corev1.ResourceServicesLoadBalancers, used.String(), hard.String())
 	}
 	return nil

--- a/api/v1/service_webhook.go
+++ b/api/v1/service_webhook.go
@@ -90,7 +90,7 @@ func (v *serviceValidator) validateService(ctx context.Context, svc *corev1.Serv
 	used := prq.Status.Used[corev1.ResourceServices]
 
 	if hard.Cmp(prq.Status.Used[corev1.ResourceServices]) != 1 {
-		return fmt.Errorf("over project resource quota. current %s counts %s, hard limit count %s", corev1.ResourceServices, hard.String(), used.String())
+		return fmt.Errorf("over project resource quota. current %s counts %s, hard limit count %s", corev1.ResourceServices, used.String(), hard.String())
 	}
 	return nil
 }
@@ -101,7 +101,7 @@ func (v *serviceValidator) validateServiceNodePort(ctx context.Context, svc *cor
 	used := prq.Status.Used[corev1.ResourceServicesNodePorts]
 
 	if hard.Cmp(prq.Status.Used[corev1.ResourceServicesNodePorts]) != 1 {
-		return fmt.Errorf("over project resource quota. current %s counts %s, hard limit count %s", corev1.ResourceServicesNodePorts, hard.String(), used.String())
+		return fmt.Errorf("over project resource quota. current %s counts %s, hard limit count %s", corev1.ResourceServicesNodePorts, used.String(), hard.String())
 	}
 	return nil
 }
@@ -112,7 +112,7 @@ func (v *serviceValidator) validateServiceLoadBalancer(ctx context.Context, svc 
 	used := prq.Status.Used[corev1.ResourceServicesLoadBalancers]
 
 	if hard.Cmp(prq.Status.Used[corev1.ResourceServicesLoadBalancers]) != 1 {
-		return fmt.Errorf("over project resource quota. current %s counts %s, hard limit count %s", corev1.ResourceServicesLoadBalancers, hard.String(), used.String())
+		return fmt.Errorf("over project resource quota. current %s counts %s, hard limit count %s", corev1.ResourceServicesLoadBalancers, used.String(), hard.String())
 	}
 	return nil
 }

--- a/internal/controller/projectresourcequota_controller.go
+++ b/internal/controller/projectresourcequota_controller.go
@@ -66,12 +66,12 @@ func (r *ProjectResourceQuotaReconciler) removeAnnotationFromObjects(ctx context
 			}
 
 			if err := jentingiov1.RemoveAnnotation(&cm, jentingiov1.ProjectResourceQuotaAnnotation); err != nil {
-				log.Error(err, "failed to remove annotation from configmap %s/%s", cm.Name, cm.Namespace)
+				log.Error(err, "failed to remove annotation from configmap", "namespace", cm.Namespace, "name", cm.Name)
 				return err
 			}
 
 			if err := r.Client.Update(ctx, &cm); err != nil {
-				log.Error(err, "failed to update configmap %s/%s", cm.Name, cm.Namespace)
+				log.Error(err, "failed to update configmap", "namespace", cm.Namespace, "name", cm.Name)
 				return err
 			}
 		}
@@ -88,12 +88,12 @@ func (r *ProjectResourceQuotaReconciler) removeAnnotationFromObjects(ctx context
 			}
 
 			if err := jentingiov1.RemoveAnnotation(&pvc, jentingiov1.ProjectResourceQuotaAnnotation); err != nil {
-				log.Error(err, "failed to remove annotation from persistentvolumeclaim %s/%s", pvc.Name, pvc.Namespace)
+				log.Error(err, "failed to remove annotation from persistentvolumeclaim", "namespace", pvc.Namespace, "name", pvc.Name)
 				return err
 			}
 
 			if err := r.Client.Update(ctx, &pvc); err != nil {
-				log.Error(err, "failed to update persistentvolumeclaim %s/%s", pvc.Name, pvc.Namespace)
+				log.Error(err, "failed to update persistentvolumeclaim", "namespace", pvc.Namespace, "name", pvc.Name)
 				return err
 			}
 		}
@@ -110,12 +110,12 @@ func (r *ProjectResourceQuotaReconciler) removeAnnotationFromObjects(ctx context
 			}
 
 			if err := jentingiov1.RemoveAnnotation(&pod, jentingiov1.ProjectResourceQuotaAnnotation); err != nil {
-				log.Error(err, "failed to remove annotation from pod %s/%s", pod.Name, pod.Namespace)
+				log.Error(err, "failed to remove annotation from pod", "namespace", pod.Namespace, "name", pod.Name)
 				return err
 			}
 
 			if err := r.Client.Update(ctx, &pod); err != nil {
-				log.Error(err, "failed to update pod %s/%s", pod.Name, pod.Namespace)
+				log.Error(err, "failed to update pod", "namespace", pod.Namespace, "name", pod.Name)
 				return err
 			}
 		}
@@ -132,12 +132,12 @@ func (r *ProjectResourceQuotaReconciler) removeAnnotationFromObjects(ctx context
 			}
 
 			if err := jentingiov1.RemoveAnnotation(&rc, jentingiov1.ProjectResourceQuotaAnnotation); err != nil {
-				log.Error(err, "failed to remove annotation from replicationcontroller %s/%s", rc.Name, rc.Namespace)
+				log.Error(err, "failed to remove annotation from replicationcontroller", "namespace", rc.Namespace, "name", rc.Name)
 				return err
 			}
 
 			if err := r.Client.Update(ctx, &rc); err != nil {
-				log.Error(err, "failed to update replicationcontroller %s/%s", rc.Name, rc.Namespace)
+				log.Error(err, "failed to update replicationcontroller", "namespace", rc.Namespace, "name", rc.Name)
 				return err
 			}
 		}
@@ -154,12 +154,12 @@ func (r *ProjectResourceQuotaReconciler) removeAnnotationFromObjects(ctx context
 			}
 
 			if err := jentingiov1.RemoveAnnotation(&rq, jentingiov1.ProjectResourceQuotaAnnotation); err != nil {
-				log.Error(err, "failed to remove annotation from resourcequota %s/%s", rq.Name, rq.Namespace)
+				log.Error(err, "failed to remove annotation from resourcequota", "namespace", rq.Namespace, "name", rq.Name)
 				return err
 			}
 
 			if err := r.Client.Update(ctx, &rq); err != nil {
-				log.Error(err, "failed to update resourcequota %s/%s", rq.Name, rq.Namespace)
+				log.Error(err, "failed to update resourcequota", "namespace", rq.Namespace, "name", rq.Name)
 				return err
 			}
 		}
@@ -176,12 +176,12 @@ func (r *ProjectResourceQuotaReconciler) removeAnnotationFromObjects(ctx context
 			}
 
 			if err := jentingiov1.RemoveAnnotation(&secret, jentingiov1.ProjectResourceQuotaAnnotation); err != nil {
-				log.Error(err, "failed to remove annotation from secret %s/%s", secret.Name, secret.Namespace)
+				log.Error(err, "failed to remove annotation from secret", "namespace", secret.Namespace, "name", secret.Name)
 				return err
 			}
 
 			if err := r.Client.Update(ctx, &secret); err != nil {
-				log.Error(err, "failed to update secret %s/%s", secret.Name, secret.Namespace)
+				log.Error(err, "failed to update secret", "namespace", secret.Namespace, "name", secret.Name)
 				return err
 			}
 		}
@@ -198,12 +198,12 @@ func (r *ProjectResourceQuotaReconciler) removeAnnotationFromObjects(ctx context
 			}
 
 			if err := jentingiov1.RemoveAnnotation(&svc, jentingiov1.ProjectResourceQuotaAnnotation); err != nil {
-				log.Error(err, "failed to remove annotation from service %s/%s", svc.Name, svc.Namespace)
+				log.Error(err, "failed to remove annotation from service", "namespace", svc.Namespace, "name", svc.Name)
 				return err
 			}
 
 			if err := r.Client.Update(ctx, &svc); err != nil {
-				log.Error(err, "failed to update service %s/%s", svc.Name, svc.Namespace)
+				log.Error(err, "failed to update service", "namespace", svc.Namespace, "name", svc.Name)
 				return err
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes three bug classes found while reviewing the webhook validators and the controller. None of these change quota-enforcement behavior (the `hard.Cmp(used)` decisions were already correct), but they make error messages and logs accurate.

### 1. Swapped `used` / `hard` in quota-exceeded error messages (8 places)
Every validator webhook formats the message as `current <res> counts <X>, hard limit count <Y>`, but passed `hard` then `used` — so operators saw the current usage and the hard limit reversed. Fixed in the pod, service (services/nodeports/loadbalancers), configmap, persistentvolumeclaim, replicationcontroller, resourcequota, and secret webhooks.

### 2. Wrong variables in Pod `limits.*` error messages (`pod_webhook.go`)
Copy-paste leftovers reported `requestCPU/Memory/EphemeralStorage` instead of the `limit*` values, and the ephemeral-storage branch named the wrong resource (`ResourceRequestsEphemeralStorage` → `ResourceLimitsEphemeralStorage`).

### 3. `log.Error` printf misuse (`projectresourcequota_controller.go`, 14 places)
logr is a structured logger and does not interpret `%s/%s`; the format verbs were emitted literally and the `Name, Namespace` args became a malformed key/value pair. Replaced with structured `namespace`/`name` fields.

## Test plan
- `go build ./...` — passes
- `go vet ./...` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)