### PR TITLE
fix: handle AddAnnotation error in annotator webhooks

### DIFF
--- a/api/v1/configmap_webhook.go
+++ b/api/v1/configmap_webhook.go
@@ -68,7 +68,9 @@ func (a *configMapAnnotator) Default(ctx context.Context, cm *corev1.ConfigMap) 
 				return nil
 			}
 
-			AddAnnotation(cm, ProjectResourceQuotaAnnotation, prq.Name)
+			if err := AddAnnotation(cm, ProjectResourceQuotaAnnotation, prq.Name); err != nil {
+				return err
+			}
 			log.Info("ConfigMap annotated")
 			return nil
 		}

--- a/api/v1/persistentvolumeclaim_webhook.go
+++ b/api/v1/persistentvolumeclaim_webhook.go
@@ -68,7 +68,9 @@ func (a *persistentVolumeClaimAnnotator) Default(ctx context.Context, pvc *corev
 				return nil
 			}
 
-			AddAnnotation(pvc, ProjectResourceQuotaAnnotation, prq.Name)
+			if err := AddAnnotation(pvc, ProjectResourceQuotaAnnotation, prq.Name); err != nil {
+				return err
+			}
 			log.Info("PersistentVolumeClaim annotated")
 			return nil
 		}

--- a/api/v1/pod_webhook.go
+++ b/api/v1/pod_webhook.go
@@ -69,7 +69,9 @@ func (a *podAnnotator) Default(ctx context.Context, pod *corev1.Pod) error {
 				return nil
 			}
 
-			AddAnnotation(pod, ProjectResourceQuotaAnnotation, prq.Name)
+			if err := AddAnnotation(pod, ProjectResourceQuotaAnnotation, prq.Name); err != nil {
+				return err
+			}
 			log.Info("Pod annotated")
 			return nil
 		}

--- a/api/v1/replicationcontroller_webhook.go
+++ b/api/v1/replicationcontroller_webhook.go
@@ -68,7 +68,9 @@ func (a *replicationControllerAnnotator) Default(ctx context.Context, rc *corev1
 				return nil
 			}
 
-			AddAnnotation(rc, ProjectResourceQuotaAnnotation, prq.Name)
+			if err := AddAnnotation(rc, ProjectResourceQuotaAnnotation, prq.Name); err != nil {
+				return err
+			}
 			log.Info("ReplicationController annotated")
 			return nil
 		}

--- a/api/v1/resourcequota_webhook.go
+++ b/api/v1/resourcequota_webhook.go
@@ -68,7 +68,9 @@ func (a *resourceQuotaAnnotator) Default(ctx context.Context, rq *corev1.Resourc
 				return nil
 			}
 
-			AddAnnotation(rq, ProjectResourceQuotaAnnotation, prq.Name)
+			if err := AddAnnotation(rq, ProjectResourceQuotaAnnotation, prq.Name); err != nil {
+				return err
+			}
 			log.Info("ResourceQuota annotated")
 			return nil
 		}

--- a/api/v1/secret_webhook.go
+++ b/api/v1/secret_webhook.go
@@ -68,7 +68,9 @@ func (a *secretAnnotator) Default(ctx context.Context, secret *corev1.Secret) er
 				return nil
 			}
 
-			AddAnnotation(secret, ProjectResourceQuotaAnnotation, prq.Name)
+			if err := AddAnnotation(secret, ProjectResourceQuotaAnnotation, prq.Name); err != nil {
+				return err
+			}
 			log.Info("Secret annotated")
 			return nil
 		}

--- a/api/v1/service_webhook.go
+++ b/api/v1/service_webhook.go
@@ -68,7 +68,9 @@ func (a *serviceAnnotator) Default(ctx context.Context, svc *corev1.Service) err
 				return nil
 			}
 
-			AddAnnotation(svc, ProjectResourceQuotaAnnotation, prq.Name)
+			if err := AddAnnotation(svc, ProjectResourceQuotaAnnotation, prq.Name); err != nil {
+				return err
+			}
 			log.Info("Service annotated")
 			return nil
 		}


### PR DESCRIPTION
## Summary

The mutating webhooks ignored the `error` returned by `AddAnnotation` in their `Default()` handlers across all seven resources (pod, service, configmap, persistentvolumeclaim, replicationcontroller, resourcequota, secret).

`AddAnnotation` only fails when the object's metadata cannot be accessed, so this is unlikely in practice — but swallowing the error means a failed annotation would silently produce an unannotated object that escapes quota tracking. The error is now propagated.

## Test plan
- `go build ./...` — passes
- `go vet ./...` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)