### PR TITLE
refactor: rename misleading loop variables in reconcile

### DIFF
--- a/internal/controller/projectresourcequota_controller.go
+++ b/internal/controller/projectresourcequota_controller.go
@@ -342,8 +342,8 @@ func (r *ProjectResourceQuotaReconciler) Reconcile(ctx context.Context, req ctrl
 			}
 
 			var count int
-			for _, pvc := range podList.Items {
-				if jentingiov1.IsAnnotationExists(&pvc, jentingiov1.ProjectResourceQuotaAnnotation) {
+			for _, pod := range podList.Items {
+				if jentingiov1.IsAnnotationExists(&pod, jentingiov1.ProjectResourceQuotaAnnotation) {
 					count++
 				}
 			}
@@ -454,8 +454,8 @@ func (r *ProjectResourceQuotaReconciler) Reconcile(ctx context.Context, req ctrl
 			}
 
 			var count int
-			for _, pvc := range rcList.Items {
-				if jentingiov1.IsAnnotationExists(&pvc, jentingiov1.ProjectResourceQuotaAnnotation) {
+			for _, rc := range rcList.Items {
+				if jentingiov1.IsAnnotationExists(&rc, jentingiov1.ProjectResourceQuotaAnnotation) {
 					count++
 				}
 			}


### PR DESCRIPTION
## Summary

The pod and replicationcontroller counting loops in `Reconcile` named their iteration variable `pvc`, evidently copied from the persistentvolumeclaim block. Renamed to `pod` and `rc` respectively so the code reads correctly. No behavior change.

## Test plan
- `go build ./...` — passes
- `go vet ./...` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)